### PR TITLE
feat: Enhance tournament page with match details

### DIFF
--- a/app/__integration_tests__/match-details.test.ts
+++ b/app/__integration_tests__/match-details.test.ts
@@ -1,0 +1,90 @@
+import { test, expect, describe, beforeAll } from '@jest/globals';
+import { prisma } from '@/lib/db';
+import { getFullMatch } from '@/lib/match';
+
+describe('Match Details Integration Test', () => {
+    let tournament;
+    let player1;
+    let player2;
+    let match;
+
+    beforeAll(async () => {
+        tournament = await prisma.tournament.create({
+            data: {
+                id: 'test-tournament-match-details-2',
+                name: 'Test Tournament 2',
+                date: new Date(),
+            },
+        });
+
+        player1 = await prisma.player.create({
+            data: {
+                id: 'test-player-1-match-details-2',
+                name: 'Player 1',
+                photo: 'https://example.com/player1.jpg',
+            },
+        });
+
+        player2 = await prisma.player.create({
+            data: {
+                id: 'test-player-2-match-details-2',
+                name: 'Player 2',
+                photo: 'https://example.com/player2.jpg',
+            },
+        });
+
+        match = await prisma.match.create({
+            data: {
+                id: 'test-match-match-details-2',
+                tournamentId: tournament.id,
+                playerAId: player1.id,
+                playerBId: player2.id,
+                playerAName: player1.name,
+                playerBName: player2.name,
+                playerAImage: player1.photo,
+                playerBImage: player2.photo,
+                raceTo: 2,
+                round: 'Final',
+            },
+        });
+
+        await prisma.playerThrow.createMany({
+            data: [
+                { id: 'throw-11-md', value: 60, double: false, leg: 1, playerId: player1.id, matchId: match.id, tournamentId: tournament.id, darts: 3 },
+                { id: 'throw-12-md', value: 50, double: false, leg: 1, playerId: player2.id, matchId: match.id, tournamentId: tournament.id, darts: 3 },
+                { id: 'throw-13-md', value: 100, double: false, leg: 1, playerId: player1.id, matchId: match.id, tournamentId: tournament.id, darts: 3 },
+                { id: 'throw-14-md', value: 101, double: false, leg: 1, playerId: player2.id, matchId: match.id, tournamentId: tournament.id, darts: 3 },
+                { id: 'throw-15-md', value: 141, double: true, leg: 1, playerId: player1.id, matchId: match.id, tournamentId: tournament.id, checkout: true, darts: 3 },
+                { id: 'throw-16-md', value: 60, double: false, leg: 2, playerId: player2.id, matchId: match.id, tournamentId: tournament.id, darts: 3 },
+                { id: 'throw-17-md', value: 50, double: false, leg: 2, playerId: player1.id, matchId: match.id, tournamentId: tournament.id, darts: 3 },
+                { id: 'throw-18-md', value: 100, double: false, leg: 2, playerId: player2.id, matchId: match.id, tournamentId: tournament.id, darts: 3 },
+                { id: 'throw-19-md', value: 101, double: false, leg: 2, playerId: player1.id, matchId: match.id, tournamentId: tournament.id, darts: 3 },
+                { id: 'throw-20-md', value: 141, double: true, leg: 2, playerId: player2.id, matchId: match.id, tournamentId: tournament.id, checkout: true, darts: 3 },
+            ],
+        });
+
+        await prisma.match.update({
+            where: { id: match.id },
+            data: {
+                playerALegs: 1,
+                playerBlegs: 1,
+            }
+        });
+    });
+
+    test('should return full match details', async () => {
+        const fullMatch = await getFullMatch(match.id, false);
+
+        expect(fullMatch).toBeDefined();
+        expect(fullMatch.id).toBe(match.id);
+        expect(fullMatch.playerA.name).toBe(player1.name);
+        expect(fullMatch.playerB.name).toBe(player2.name);
+        expect(fullMatch.playerA.legCount).toBe(1);
+        expect(fullMatch.playerB.legCount).toBe(1);
+        expect(fullMatch.throws.length).toBe(10);
+        expect(fullMatch.playerA.matchAvg).toBeCloseTo(100.33);
+        expect(fullMatch.playerB.matchAvg).toBeCloseTo(100.33);
+        expect(fullMatch.playerA.bestCheckout).toBe(141);
+        expect(fullMatch.playerB.bestCheckout).toBe(141);
+    });
+});

--- a/app/__integration_tests__/match-details.test.ts
+++ b/app/__integration_tests__/match-details.test.ts
@@ -1,6 +1,6 @@
-import { test, expect, describe, beforeAll } from '@jest/globals';
-import { prisma } from '@/lib/db';
-import { getFullMatch } from '@/lib/match';
+import { test, expect, describe, beforeAll, afterAll, beforeEach, afterEach } from '@jest/globals';
+import { prisma } from '../lib/db';
+import { getFullMatch } from '../lib/match';
 
 describe('Match Details Integration Test', () => {
     let tournament;
@@ -9,6 +9,16 @@ describe('Match Details Integration Test', () => {
     let match;
 
     beforeAll(async () => {
+        await prisma.playerThrow.deleteMany();
+        await prisma.match.deleteMany();
+        await prisma.tournament.deleteMany();
+    });
+
+    beforeEach(async () => {
+        await prisma.playerThrow.deleteMany();
+        await prisma.match.deleteMany();
+        await prisma.tournament.deleteMany();
+
         tournament = await prisma.tournament.create({
             data: {
                 id: 'test-tournament-match-details-2',
@@ -70,6 +80,19 @@ describe('Match Details Integration Test', () => {
                 playerBlegs: 1,
             }
         });
+    });
+
+    afterEach(async () => {
+        await prisma.playerThrow.deleteMany();
+        await prisma.match.deleteMany();
+        await prisma.tournament.deleteMany();
+    });
+
+    afterAll(async () => {
+        await prisma.playerThrow.deleteMany();
+        await prisma.match.deleteMany();
+        await prisma.tournament.deleteMany();
+        await prisma.$disconnect();
     });
 
     test('should return full match details', async () => {

--- a/app/__integration_tests__/match.test.ts
+++ b/app/__integration_tests__/match.test.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import prisma from '@/app/lib/db';
-import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import {
     findMatch,
     upsertMatch,
@@ -13,7 +13,19 @@ import {
 const prismaTest = prisma as unknown as PrismaClient;
 
 describe('Match Integration Tests', () => {
+    beforeAll(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
+        await prismaTest.tournament.deleteMany();
+    });
+
     beforeEach(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
+        await prismaTest.tournament.deleteMany();
+    });
+
+    afterEach(async () => {
         await prismaTest.playerThrow.deleteMany();
         await prismaTest.match.deleteMany();
         await prismaTest.tournament.deleteMany();

--- a/app/__integration_tests__/playerThrow.test.ts
+++ b/app/__integration_tests__/playerThrow.test.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import prisma from '@/app/lib/db';
-import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { afterAll, afterEach, describe, expect, test } from '@jest/globals';
 import {
     findThrowsByMatchAndLeg,
     aggregatePlayerThrow,
@@ -15,7 +15,7 @@ import {
 const prismaTest = prisma as unknown as PrismaClient;
 
 describe('Player Throw Integration Tests', () => {
-    beforeEach(async () => {
+    afterEach(async () => {
         await prismaTest.playerThrow.deleteMany();
         await prismaTest.match.deleteMany();
         await prismaTest.tournament.deleteMany();

--- a/app/__integration_tests__/playerThrow.test.ts
+++ b/app/__integration_tests__/playerThrow.test.ts
@@ -1,6 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import prisma from '@/app/lib/db';
-import { afterAll, afterEach, describe, expect, test } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import {
     findThrowsByMatchAndLeg,
     aggregatePlayerThrow,
@@ -15,6 +15,18 @@ import {
 const prismaTest = prisma as unknown as PrismaClient;
 
 describe('Player Throw Integration Tests', () => {
+    beforeAll(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
+        await prismaTest.tournament.deleteMany();
+    });
+
+    beforeEach(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
+        await prismaTest.tournament.deleteMany();
+    });
+
     afterEach(async () => {
         await prismaTest.playerThrow.deleteMany();
         await prismaTest.match.deleteMany();

--- a/app/__integration_tests__/players.test.ts
+++ b/app/__integration_tests__/players.test.ts
@@ -1,12 +1,24 @@
 import { PrismaClient } from '@prisma/client';
 import prisma from '@/app/lib/db';
-import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import { findPlayersByTournament } from '@/app/lib/data';
 
 const prismaTest = prisma as unknown as PrismaClient;
 
 describe('Players Integration Tests', () => {
+    beforeAll(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
+        await prismaTest.tournament.deleteMany();
+    });
+
     beforeEach(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
+        await prismaTest.tournament.deleteMany();
+    });
+
+    afterEach(async () => {
         await prismaTest.playerThrow.deleteMany();
         await prismaTest.match.deleteMany();
         await prismaTest.tournament.deleteMany();

--- a/app/__integration_tests__/tournament.test.ts
+++ b/app/__integration_tests__/tournament.test.ts
@@ -36,9 +36,9 @@ describe('Tournament Integration Tests', () => {
     test('should find tournaments by name', async () => {
         await prismaTest.tournament.createMany({
             data: [
-                { id: '1', name: 'Tournament A' },
-                { id: '2', name: 'Tournament B' },
-                { id: '3', name: 'Another Tournament' },
+                { id: '4', name: 'Tournament A' },
+                { id: '5', name: 'Tournament B' },
+                { id: '6', name: 'Another Tournament' },
             ],
         });
 
@@ -51,9 +51,9 @@ describe('Tournament Integration Tests', () => {
     test('should find tournaments by year', async () => {
         await prismaTest.tournament.createMany({
             data: [
-                { id: '1', name: 'Tournament 2023 A' },
-                { id: '2', name: 'Tournament 2023 B' },
-                { id: '3', name: 'Tournament 2024' },
+                { id: '7', name: 'Tournament 2023 A' },
+                { id: '8', name: 'Tournament 2023 B' },
+                { id: '9', name: 'Tournament 2024' },
             ],
         });
 

--- a/app/__integration_tests__/tournament.test.ts
+++ b/app/__integration_tests__/tournament.test.ts
@@ -1,16 +1,32 @@
 import { PrismaClient } from '@prisma/client';
 import prisma from '@/app/lib/db';
-import { afterAll, beforeEach, describe, expect, test } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from '@jest/globals';
 import { upsertTournament, findTournamentsByName, findTournamentsByYear } from '@/app/lib/data';
 
 const prismaTest = prisma as unknown as PrismaClient;
 
 describe('Tournament Integration Tests', () => {
+    beforeAll(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
+        await prismaTest.tournament.deleteMany();
+    });
+
     beforeEach(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
+        await prismaTest.tournament.deleteMany();
+    });
+
+    afterEach(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
         await prismaTest.tournament.deleteMany();
     });
 
     afterAll(async () => {
+        await prismaTest.playerThrow.deleteMany();
+        await prismaTest.match.deleteMany();
         await prismaTest.tournament.deleteMany();
         await prismaTest.$disconnect();
     });

--- a/app/__tests__/cuescore.test.ts
+++ b/app/__tests__/cuescore.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import axios from 'axios';
 import getTournamentInfo, { setScore, finishMatch, getRankings, getResults } from '../lib/cuescore';
-import { mockedAxios } from './mocks';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 jest.mock('next/cache', () => ({
     revalidateTag: jest.fn(),

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,0 +1,11 @@
+export function Header({ text }) {
+    return (
+        <span className="flex items-center">
+            <span className="h-px flex-1 bg-gradient-to-r from-transparent to-gray-300"></span>
+
+            <span className="text-2xl shrink-0 px-4 text-gray-900">{text}</span>
+
+            <span className="h-px flex-1 bg-gradient-to-l from-transparent to-gray-300"></span>
+        </span>
+    )
+}

--- a/app/dashboard/tournament/[tournamentId]/page.tsx
+++ b/app/dashboard/tournament/[tournamentId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
 
 async function fetchServerData(tournamentId, test) {
     const response = await fetch(`/api/dashboard/tournament/${tournamentId}${test ? `?test=${test}` : ''}`);
@@ -33,7 +34,7 @@ export default function DashboardPage({ params }: { params: { tournamentId: stri
         intervalId = setInterval(fetchData, 1000); // Poll every second
 
         return () => clearInterval(intervalId); // Cleanup on unmount
-    }, []);
+    }, [params.tournamentId, searchParams]);
 
     if (error) {
         return <div>Error: {error}</div>;
@@ -106,9 +107,11 @@ function TableDashboard({ tableId, match, matchInfo, lastThrows, firstPlayer }: 
 function Winner({ player, image }: { player: string, image: string }) {
     return (
         <div className="flex flex-col items-center justify-center space-y-2 w-full h-full">
-            <img
+            <Image
                 src={image}
-                alt={`Winner` + player}
+                alt={`Winner: ${player}`}
+                width={128}
+                height={128}
                 className="w-32 h-32 object-cover"
             />
             <p className="text-2xl font-semibold text-blue-800">{player}</p>
@@ -123,9 +126,11 @@ function Player({ playerId, playerName, photo, active, legsWon, score, lastThrow
 }) {
     return (
         <div className={`flex flex-col items-center space-y-4 flex-1 ${active ? "bg-yellow-50" : ""}`}>
-            <img
+            <Image
                 src={photo}
                 alt={`Player ${playerName} - ${playerId}`}
+                width={112}
+                height={112}
                 className="w-28 h-28"
             />
             <h2 className="text-xl text-center px-1 font-bold text-blue-700">{playerName}</h2>

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -25,6 +25,18 @@ export async function upsertTournament(tournamentId: string, name: string, tx?: 
     });
 }
 
+export async function findThrowsByMatch(matchId: string, tx?: PrismaTransactionClient) {
+    const client = getPrismaClient(tx);
+    return client.playerThrow.findMany({
+        where: {
+            matchId: matchId,
+        },
+        orderBy: {
+            time: 'asc'
+        }
+    });
+}
+
 export async function findTournamentsByName(tournamentNames: string[], tx?: PrismaTransactionClient) {
     const client = getPrismaClient(tx);
     return client.tournament.findMany({
@@ -282,4 +294,13 @@ export async function findPlayersByTournament(tournaments: string[], tx?: Prisma
         }
     });
     return { playersA, playersB };
+}
+
+export async function findMatchesByTournament(tournamentId: string, tx?: PrismaTransactionClient) {
+    const client = getPrismaClient(tx);
+    return client.match.findMany({
+        where: {
+            tournamentId: tournamentId
+        }
+    });
 }

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -25,6 +25,55 @@ export async function upsertTournament(tournamentId: string, name: string, tx?: 
     });
 }
 
+export async function findHighestScoreInMatch(matchId: string, playerId: string, tx?: PrismaTransactionClient) {
+    const client = getPrismaClient(tx);
+    const result = await client.playerThrow.aggregate({
+        _max: {
+            score: true,
+        },
+        where: {
+            matchId: matchId,
+            playerId: playerId,
+        },
+    });
+    return result._max.score || 0;
+}
+
+export async function findBestCheckoutInMatch(matchId: string, playerId: string, tx?: PrismaTransactionClient) {
+    const client = getPrismaClient(tx);
+    const result = await client.playerThrow.aggregate({
+        _max: {
+            score: true,
+        },
+        where: {
+            matchId: matchId,
+            playerId: playerId,
+            checkout: true,
+        },
+    });
+    return result._max.score || 0;
+}
+
+export async function findBestLegInMatch(matchId: string, playerId: string, tx?: PrismaTransactionClient) {
+    const client = getPrismaClient(tx);
+    const result = await client.playerThrow.groupBy({
+        by: ['leg'],
+        _sum: {
+            darts: true,
+        },
+        where: {
+            matchId: matchId,
+            playerId: playerId,
+        },
+        orderBy: {
+            _sum: {
+                darts: 'asc',
+            },
+        },
+    });
+    return result[0]?._sum.darts || 0;
+}
+
 export async function findThrowsByMatch(matchId: string, tx?: PrismaTransactionClient) {
     const client = getPrismaClient(tx);
     return client.playerThrow.findMany({

--- a/app/lib/match.ts
+++ b/app/lib/match.ts
@@ -4,7 +4,7 @@ import getTournamentInfo from "./cuescore"
 import { revalidatePath, revalidateTag } from "next/cache";
 import { FullMatch, Player } from "./model/fullmatch";
 import { findLastThrow, findMatchAvg } from "./playerThrow";
-import { findMatch, upsertMatch, updateMatchFirstPlayer, resetMatchData, findThrowsByMatchAndLeg } from "./data";
+import { findMatch, upsertMatch, updateMatchFirstPlayer, resetMatchData, findThrowsByMatchAndLeg, findThrowsByMatch } from "./data";
 
 interface CueScorePlayer {
   playerId: number;
@@ -49,6 +49,7 @@ export async function getFullMatch(matchId, slow) {
   const playerBLast = (await findLastThrow(match.id, leg, match.playerBId))?.score;
   const playerAAvg = (await findMatchAvg(match.id, match.playerAId));
   const playerBAvg = (await findMatchAvg(match.id, match.playerBId));
+  const throws = await findThrowsByMatch(matchId);
 
   const playerA: Player = {
     id: match.playerAId,
@@ -80,7 +81,8 @@ export async function getFullMatch(matchId, slow) {
     currentLeg: leg,
     nextPlayer: scores.nextPlayer,
     playerA: playerA,
-    playerB: playerB
+    playerB: playerB,
+    throws: throws
   }
   return fullMatch;
 }

--- a/app/lib/match.ts
+++ b/app/lib/match.ts
@@ -4,7 +4,7 @@ import getTournamentInfo from "./cuescore"
 import { revalidatePath, revalidateTag } from "next/cache";
 import { FullMatch, Player } from "./model/fullmatch";
 import { findLastThrow, findMatchAvg } from "./playerThrow";
-import { findMatch, upsertMatch, updateMatchFirstPlayer, resetMatchData, findThrowsByMatchAndLeg, findThrowsByMatch } from "./data";
+import { findMatch, upsertMatch, updateMatchFirstPlayer, resetMatchData, findThrowsByMatchAndLeg, findThrowsByMatch, findHighestScoreInMatch, findBestCheckoutInMatch, findBestLegInMatch } from "./data";
 
 interface CueScorePlayer {
   playerId: number;
@@ -60,7 +60,10 @@ export async function getFullMatch(matchId, slow) {
     lastThrow: playerALast,
     matchAvg: playerAAvg,
     legCount: match.playerALegs,
-    active: scores.nextPlayer == match.playerAId
+    active: scores.nextPlayer == match.playerAId,
+    highestScore: await findHighestScoreInMatch(matchId, match.playerAId),
+    bestCheckout: await findBestCheckoutInMatch(matchId, match.playerAId),
+    bestLeg: await findBestLegInMatch(matchId, match.playerAId),
   }
 
   const playerB: Player = {
@@ -72,7 +75,10 @@ export async function getFullMatch(matchId, slow) {
     lastThrow: playerBLast,
     matchAvg: playerBAvg,
     legCount: match.playerBlegs,
-    active: scores.nextPlayer == match.playerBId
+    active: scores.nextPlayer == match.playerBId,
+    highestScore: await findHighestScoreInMatch(matchId, match.playerBId),
+    bestCheckout: await findBestCheckoutInMatch(matchId, match.playerBId),
+    bestLeg: await findBestLegInMatch(matchId, match.playerBId),
   }
 
   const fullMatch: FullMatch = {

--- a/app/lib/model/fullmatch.ts
+++ b/app/lib/model/fullmatch.ts
@@ -1,13 +1,13 @@
-import { Match, Tournament } from "@prisma/client"
+import { Match, PlayerThrow, Tournament } from "@prisma/client"
 
 export type FullMatch = {
-    match : Match
+    match: Match
     tournament: Tournament
     currentLeg: number
     nextPlayer: string
     playerA: Player
     playerB: Player
-
+    throws: PlayerThrow[]
 }
 
 export type Player = {

--- a/app/lib/model/fullmatch.ts
+++ b/app/lib/model/fullmatch.ts
@@ -20,4 +20,7 @@ export type Player = {
     matchAvg: number
     legCount: number
     active: boolean;
+    highestScore: number;
+    bestCheckout: number;
+    bestLeg: number;
 }

--- a/app/stats/tournaments/[id]/page.tsx
+++ b/app/stats/tournaments/[id]/page.tsx
@@ -244,14 +244,28 @@ export default async function TournamentStats({ params }: { params: { id: string
 
 function MatchesList({ matches, tournamentId }) {
     const roundOrder = {
-        "Finále": 1,
-        "Semifinále": 2,
-        "Štvrťfinále": 3,
+        "Final": 1,
+        "Semi-final": 2,
+        "Quarter-final": 3,
+        "Last 16": 4,
+        "Last 32": 5,
+        "Last 64": 6,
+        "Last 128": 7,
+    };
+
+    const roundTranslations = {
+        "Final": "Finále",
+        "Semi-final": "Semifinále",
+        "Quarter-final": "Štvrťfinále",
+        "Last 16": "Osemfinále",
+        "Last 32": "Šestnásťfinále",
+        "Last 64": "1/32-finále",
+        "Last 128": "1/64-finále",
     };
 
     const sortedMatches = [...matches].sort((a, b) => {
-        const roundA = roundOrder[a.round] || parseInt(a.round.split(" ")[1]) + 3;
-        const roundB = roundOrder[b.round] || parseInt(b.round.split(" ")[1]) + 3;
+        const roundA = roundOrder[a.round] || (a.round.includes("Round") ? parseInt(a.round.split(" ")[1]) + 10 : 99);
+        const roundB = roundOrder[b.round] || (b.round.includes("Round") ? parseInt(b.round.split(" ")[1]) + 10 : 99);
         return roundA - roundB;
     });
 
@@ -273,13 +287,13 @@ function MatchesList({ matches, tournamentId }) {
                 <tbody className="divide-y divide-gray-200 *:even:bg-gray-50">
                     {
                         sortedMatches.map((match) => {
-                            const winner = match.playerALegs > match.playerBlegs ? match.playerAId : match.playerBId;
+                            const winnerId = match.playerALegs > match.playerBlegs ? match.playerAId : match.playerBId;
                             return (
                                 <tr key={match.id} className="*:text-gray-900 *:first:font-medium">
-                                    <td className="px-1 py-2 whitespace-nowrap">{match.round}</td>
-                                    <td className={`px-3 py-2 whitespace-nowrap ${winner === match.playerAId ? 'font-bold' : ''}`}>{match.playerAName}</td>
-                                    <td className="px-3 py-2 whitespace-nowrap">{match.playerALegs} : {match.playerBlegs}</td>
-                                    <td className={`px-3 py-2 whitespace-nowrap ${winner === match.playerBId ? 'font-bold' : ''}`}>{match.playerBName}</td>
+                                    <td className="px-1 py-2 whitespace-nowrap">{roundTranslations[match.round] || match.round}</td>
+                                    <td className={`px-3 py-2 whitespace-nowrap ${winnerId === match.playerAId ? 'font-bold' : ''}`}>{match.playerAName}</td>
+                                    <td className={`px-3 py-2 whitespace-nowrap ${winnerId ? 'font-bold' : ''}`}>{match.playerALegs} : {match.playerBlegs}</td>
+                                    <td className={`px-3 py-2 whitespace-nowrap ${winnerId === match.playerBId ? 'font-bold' : ''}`}>{match.playerBName}</td>
                                     <td className="px-3 py-2 whitespace-nowrap">
                                         <Link href={`/tournaments/${tournamentId}/match/${match.id}`} className="text-sky-500 hover:text-sky-700">Detail</Link>
                                     </td>

--- a/app/stats/tournaments/[id]/page.tsx
+++ b/app/stats/tournaments/[id]/page.tsx
@@ -243,6 +243,18 @@ export default async function TournamentStats({ params }: { params: { id: string
 }
 
 function MatchesList({ matches, tournamentId }) {
+    const roundOrder = {
+        "Finále": 1,
+        "Semifinále": 2,
+        "Štvrťfinále": 3,
+    };
+
+    const sortedMatches = [...matches].sort((a, b) => {
+        const roundA = roundOrder[a.round] || parseInt(a.round.split(" ")[1]) + 3;
+        const roundB = roundOrder[b.round] || parseInt(b.round.split(" ")[1]) + 3;
+        return roundA - roundB;
+    });
+
     return (
         <div className="overflow-x-auto">
             <Header text={"Zápasy"} />
@@ -260,17 +272,20 @@ function MatchesList({ matches, tournamentId }) {
 
                 <tbody className="divide-y divide-gray-200 *:even:bg-gray-50">
                     {
-                        matches.map((match) => (
-                            <tr key={match.id} className="*:text-gray-900 *:first:font-medium">
-                                <td className="px-1 py-2 whitespace-nowrap">{match.round}</td>
-                                <td className="px-3 py-2 whitespace-nowrap">{match.playerAName}</td>
-                                <td className="px-3 py-2 whitespace-nowrap">{match.playerALegs} : {match.playerBlegs}</td>
-                                <td className="px-3 py-2 whitespace-nowrap">{match.playerBName}</td>
-                                <td className="px-3 py-2 whitespace-nowrap">
-                                    <Link href={`/tournaments/${tournamentId}/match/${match.id}`} className="text-sky-500 hover:text-sky-700">Detail</Link>
-                                </td>
-                            </tr>
-                        ))
+                        sortedMatches.map((match) => {
+                            const winner = match.playerALegs > match.playerBlegs ? match.playerAId : match.playerBId;
+                            return (
+                                <tr key={match.id} className="*:text-gray-900 *:first:font-medium">
+                                    <td className="px-1 py-2 whitespace-nowrap">{match.round}</td>
+                                    <td className={`px-3 py-2 whitespace-nowrap ${winner === match.playerAId ? 'font-bold' : ''}`}>{match.playerAName}</td>
+                                    <td className="px-3 py-2 whitespace-nowrap">{match.playerALegs} : {match.playerBlegs}</td>
+                                    <td className={`px-3 py-2 whitespace-nowrap ${winner === match.playerBId ? 'font-bold' : ''}`}>{match.playerBName}</td>
+                                    <td className="px-3 py-2 whitespace-nowrap">
+                                        <Link href={`/tournaments/${tournamentId}/match/${match.id}`} className="text-sky-500 hover:text-sky-700">Detail</Link>
+                                    </td>
+                                </tr>
+                            )
+                        })
                     }
                 </tbody>
             </table>

--- a/app/tournaments/[id]/match/[matchId]/page.tsx
+++ b/app/tournaments/[id]/match/[matchId]/page.tsx
@@ -1,0 +1,126 @@
+import { getFullMatch } from "@/app/lib/match";
+import Link from "next/link";
+
+export default async function MatchPage({ params }: { params: { id: string, matchId: string } }) {
+    const fullMatch = await getFullMatch(params.matchId, false);
+
+    if (!fullMatch) {
+        return (
+            <div className="w-full h-screen flex items-center justify-center bg-white text-black">
+                <h1 className="text-2xl font-bold">Zápas nenájdený...</h1>
+            </div>
+        )
+    }
+
+    return (
+        <div className="w-full min-h-screen text-gray-900 bg-white">
+            <header className="sticky top-0 z-40 w-full backdrop-blur flex-none">
+                <div className="max-w-7xl mx-auto">
+                    <div className="py-4 px-4 border-b border-gray-200 dark:border-gray-800">
+                        <div className="relative flex items-center">
+                            <div className="font-bold text-xl">
+                                {fullMatch.playerA.name} vs {fullMatch.playerB.name}
+                            </div>
+                            <div className="relative flex items-center ml-auto">
+                                <nav className="text-sm leading-6 font-semibold text-slate-700">
+                                    <ul className="flex space-x-8">
+                                        <li>
+                                            <Link className="hover:text-sky-500" href={`/stats/tournaments/${params.id}`}>Späť na turnaj</Link>
+                                        </li>
+                                    </ul>
+                                </nav>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </header>
+            <main className="flex-auto">
+                <div className="max-w-7xl mx-auto py-4 px-4">
+                    <PlayerStats playerA={fullMatch.playerA} playerB={fullMatch.playerB} />
+                    <ThrowsList throws={fullMatch.throws} playerA={fullMatch.playerA} playerB={fullMatch.playerB} />
+                </div>
+            </main>
+        </div>
+    )
+}
+
+function PlayerStats({ playerA, playerB }) {
+    return (
+        <div className="overflow-x-auto">
+            <table className="min-w-full divide-y-2 divide-gray-200">
+                <thead className="text-left ltr:text-left rtl:text-right">
+                    <tr className="*:font-medium *:text-gray-900">
+                        <th className="px-1 py-2 whitespace-nowrap">Meno</th>
+                        <th className="px-3 py-2 whitespace-nowrap">Priemer</th>
+                        <th className="px-3 py-2 whitespace-nowrap">Legy</th>
+                    </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 *:even:bg-gray-50">
+                    <tr className="*:text-gray-900">
+                        <td className="px-1 py-2 whitespace-nowrap">{playerA.name}</td>
+                        <td className="px-3 py-2 whitespace-nowrap">{playerA.matchAvg.toFixed(2)}</td>
+                        <td className="px-3 py-2 whitespace-nowrap">{playerA.legCount}</td>
+                    </tr>
+                    <tr className="*:text-gray-900">
+                        <td className="px-1 py-2 whitespace-nowrap">{playerB.name}</td>
+                        <td className="px-3 py-2 whitespace-nowrap">{playerB.matchAvg.toFixed(2)}</td>
+                        <td className="px-3 py-2 whitespace-nowrap">{playerB.legCount}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    )
+}
+
+function ThrowsList({ throws, playerA, playerB }) {
+    const throwsByLeg = throws.reduce((acc, T) => {
+        if (!acc[T.leg]) {
+            acc[T.leg] = [];
+        }
+        acc[T.leg].push(T);
+        return acc;
+    }, {});
+
+    return (
+        <div className="mt-8">
+            {Object.entries(throwsByLeg).map(([leg, legThrows]) => (
+                <div key={leg}>
+                    <h2 className="text-xl font-bold mt-4">Leg {leg}</h2>
+                    <div className="overflow-x-auto">
+                        <table className="min-w-full divide-y-2 divide-gray-200">
+                            <thead className="text-left ltr:text-left rtl:text-right">
+                                <tr className="*:font-medium *:text-gray-900">
+                                    <th className="px-1 py-2 whitespace-nowrap">{playerA.name}</th>
+                                    <th className="px-3 py-2 whitespace-nowrap">{playerB.name}</th>
+                                </tr>
+                            </thead>
+                            <tbody className="divide-y divide-gray-200 *:even:bg-gray-50">
+                                {getLegRows(legThrows, playerA.id, playerB.id).map((row, i) => (
+                                    <tr key={i} className="*:text-gray-900">
+                                        <td className="px-1 py-2 whitespace-nowrap">{row.playerA}</td>
+                                        <td className="px-3 py-2 whitespace-nowrap">{row.playerB}</td>
+                                    </tr>
+                                ))}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+function getLegRows(legThrows, playerAId, playerBId) {
+    const rows = [];
+    let playerAThrows = legThrows.filter(t => t.playerId === playerAId).map(t => t.score);
+    let playerBThrows = legThrows.filter(t => t.playerId === playerBId).map(t => t.score);
+    const numRows = Math.max(playerAThrows.length, playerBThrows.length);
+
+    for (let i = 0; i < numRows; i++) {
+        rows.push({
+            playerA: playerAThrows[i] || '',
+            playerB: playerBThrows[i] || '',
+        });
+    }
+    return rows;
+}

--- a/app/tournaments/[id]/match/[matchId]/page.tsx
+++ b/app/tournaments/[id]/match/[matchId]/page.tsx
@@ -46,28 +46,33 @@ export default async function MatchPage({ params }: { params: { id: string, matc
 
 function PlayerStats({ playerA, playerB }) {
     return (
-        <div className="overflow-x-auto">
-            <table className="min-w-full divide-y-2 divide-gray-200">
-                <thead className="text-left ltr:text-left rtl:text-right">
-                    <tr className="*:font-medium *:text-gray-900">
-                        <th className="px-1 py-2 whitespace-nowrap">Meno</th>
-                        <th className="px-3 py-2 whitespace-nowrap">Priemer</th>
-                        <th className="px-3 py-2 whitespace-nowrap">Legy</th>
-                    </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200 *:even:bg-gray-50">
-                    <tr className="*:text-gray-900">
-                        <td className="px-1 py-2 whitespace-nowrap">{playerA.name}</td>
-                        <td className="px-3 py-2 whitespace-nowrap">{playerA.matchAvg.toFixed(2)}</td>
-                        <td className="px-3 py-2 whitespace-nowrap">{playerA.legCount}</td>
-                    </tr>
-                    <tr className="*:text-gray-900">
-                        <td className="px-1 py-2 whitespace-nowrap">{playerB.name}</td>
-                        <td className="px-3 py-2 whitespace-nowrap">{playerB.matchAvg.toFixed(2)}</td>
-                        <td className="px-3 py-2 whitespace-nowrap">{playerB.legCount}</td>
-                    </tr>
-                </tbody>
-            </table>
+        <div className="flex justify-around">
+            <div className="w-1/2 p-4">
+                <div className="flex items-center">
+                    <img src={playerA.imageUrl} className="w-12 h-12 rounded-full" alt={playerA.name} />
+                    <h2 className="text-2xl font-bold ml-4">{playerA.name}</h2>
+                </div>
+                <div className="mt-4">
+                    <p><strong>Priemer:</strong> {playerA.matchAvg.toFixed(2)}</p>
+                    <p><strong>Legy:</strong> {playerA.legCount}</p>
+                    <p><strong>Najvyšší náhod:</strong> {playerA.highestScore}</p>
+                    <p><strong>Najlepší checkout:</strong> {playerA.bestCheckout}</p>
+                    <p><strong>Najlepší leg:</strong> {playerA.bestLeg}</p>
+                </div>
+            </div>
+            <div className="w-1/2 p-4">
+                <div className="flex items-center">
+                    <img src={playerB.imageUrl} className="w-12 h-12 rounded-full" alt={playerB.name} />
+                    <h2 className="text-2xl font-bold ml-4">{playerB.name}</h2>
+                </div>
+                <div className="mt-4">
+                    <p><strong>Priemer:</strong> {playerB.matchAvg.toFixed(2)}</p>
+                    <p><strong>Legy:</strong> {playerB.legCount}</p>
+                    <p><strong>Najvyšší náhod:</strong> {playerB.highestScore}</p>
+                    <p><strong>Najlepší checkout:</strong> {playerB.bestCheckout}</p>
+                    <p><strong>Najlepší leg:</strong> {playerB.bestLeg}</p>
+                </div>
+            </div>
         </div>
     )
 }
@@ -83,44 +88,65 @@ function ThrowsList({ throws, playerA, playerB }) {
 
     return (
         <div className="mt-8">
-            {Object.entries(throwsByLeg).map(([leg, legThrows]) => (
-                <div key={leg}>
-                    <h2 className="text-xl font-bold mt-4">Leg {leg}</h2>
-                    <div className="overflow-x-auto">
-                        <table className="min-w-full divide-y-2 divide-gray-200">
-                            <thead className="text-left ltr:text-left rtl:text-right">
-                                <tr className="*:font-medium *:text-gray-900">
-                                    <th className="px-1 py-2 whitespace-nowrap">{playerA.name}</th>
-                                    <th className="px-3 py-2 whitespace-nowrap">{playerB.name}</th>
-                                </tr>
-                            </thead>
-                            <tbody className="divide-y divide-gray-200 *:even:bg-gray-50">
-                                {getLegRows(legThrows, playerA.id, playerB.id).map((row, i) => (
-                                    <tr key={i} className="*:text-gray-900">
-                                        <td className="px-1 py-2 whitespace-nowrap">{row.playerA}</td>
-                                        <td className="px-3 py-2 whitespace-nowrap">{row.playerB}</td>
+            {Object.entries(throwsByLeg).map(([leg, legThrows]: [string, any[]]) => {
+                const legWinner = legThrows.find(t => t.checkout)?.playerId;
+                return (
+                    <div key={leg}>
+                        <h2 className={`text-xl font-bold mt-4 ${legWinner === playerA.id ? 'text-blue-700' : legWinner === playerB.id ? 'text-red-700' : ''}`}>
+                            Leg {leg}
+                        </h2>
+                        <div className="overflow-x-auto">
+                            <table className="min-w-full divide-y-2 divide-gray-200">
+                                <thead className="text-left ltr:text-left rtl:text-right">
+                                    <tr className="*:font-medium *:text-gray-900">
+                                        <th className="px-1 py-2 whitespace-nowrap">{playerA.name}</th>
+                                        <th className="px-3 py-2 whitespace-nowrap">{playerB.name}</th>
                                     </tr>
-                                ))}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody className="divide-y divide-gray-200 *:even:bg-gray-50">
+                                    {getLegRows(legThrows, playerA.id, playerB.id).map((row, i) => (
+                                        <tr key={i} className="*:text-gray-900">
+                                            <td className={`px-1 py-2 whitespace-nowrap ${row.playerA?.first ? 'font-bold' : ''} ${row.playerA?.checkout ? 'text-green-600' : ''}`}>
+                                                {row.playerA?.score}
+                                            </td>
+                                            <td className={`px-3 py-2 whitespace-nowrap ${row.playerB?.first ? 'font-bold' : ''} ${row.playerB?.checkout ? 'text-green-600' : ''}`}>
+                                                {row.playerB?.score}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
-                </div>
-            ))}
+                )
+            })}
         </div>
     )
 }
 
 function getLegRows(legThrows, playerAId, playerBId) {
     const rows = [];
-    let playerAThrows = legThrows.filter(t => t.playerId === playerAId).map(t => t.score);
-    let playerBThrows = legThrows.filter(t => t.playerId === playerBId).map(t => t.score);
+    const playerAThrows = legThrows.filter(t => t.playerId === playerAId);
+    const playerBThrows = legThrows.filter(t => t.playerId === playerBId);
     const numRows = Math.max(playerAThrows.length, playerBThrows.length);
 
     for (let i = 0; i < numRows; i++) {
-        rows.push({
-            playerA: playerAThrows[i] || '',
-            playerB: playerBThrows[i] || '',
-        });
+        const row = { playerA: null, playerB: null };
+        if (playerAThrows[i]) {
+            row.playerA = {
+                score: playerAThrows[i].score,
+                checkout: playerAThrows[i].checkout,
+                first: i === 0,
+            };
+        }
+        if (playerBThrows[i]) {
+            row.playerB = {
+                score: playerBThrows[i].score,
+                checkout: playerBThrows[i].checkout,
+                first: i === 0,
+            };
+        }
+        rows.push(row);
     }
     return rows;
 }

--- a/app/tournaments/[id]/match/[matchId]/page.tsx
+++ b/app/tournaments/[id]/match/[matchId]/page.tsx
@@ -1,5 +1,6 @@
 import { getFullMatch } from "@/app/lib/match";
 import Link from "next/link";
+import Image from "next/image";
 
 export default async function MatchPage({ params }: { params: { id: string, matchId: string } }) {
     const fullMatch = await getFullMatch(params.matchId, false);
@@ -49,12 +50,12 @@ function PlayerStats({ playerA, playerB }) {
         <div className="flex justify-around">
             <div className="w-1/2 p-4">
                 <div className="flex items-center">
-                    <img src={playerA.imageUrl} className="w-12 h-12 rounded-full" alt={playerA.name} />
+                    <Image src={playerA.imageUrl} width={48} height={48} className="w-12 h-12 rounded-full" alt={playerA.name} />
                     <h2 className="text-2xl font-bold ml-4">{playerA.name}</h2>
+                    <span className="text-2xl font-bold ml-2">({playerA.legCount})</span>
                 </div>
                 <div className="mt-4">
                     <p><strong>Priemer:</strong> {playerA.matchAvg.toFixed(2)}</p>
-                    <p><strong>Legy:</strong> {playerA.legCount}</p>
                     <p><strong>Najvyšší náhod:</strong> {playerA.highestScore}</p>
                     <p><strong>Najlepší checkout:</strong> {playerA.bestCheckout}</p>
                     <p><strong>Najlepší leg:</strong> {playerA.bestLeg}</p>
@@ -62,12 +63,12 @@ function PlayerStats({ playerA, playerB }) {
             </div>
             <div className="w-1/2 p-4">
                 <div className="flex items-center">
-                    <img src={playerB.imageUrl} className="w-12 h-12 rounded-full" alt={playerB.name} />
+                    <Image src={playerB.imageUrl} width={48} height={48} className="w-12 h-12 rounded-full" alt={playerB.name} />
                     <h2 className="text-2xl font-bold ml-4">{playerB.name}</h2>
+                    <span className="text-2xl font-bold ml-2">({playerB.legCount})</span>
                 </div>
                 <div className="mt-4">
                     <p><strong>Priemer:</strong> {playerB.matchAvg.toFixed(2)}</p>
-                    <p><strong>Legy:</strong> {playerB.legCount}</p>
                     <p><strong>Najvyšší náhod:</strong> {playerB.highestScore}</p>
                     <p><strong>Najlepší checkout:</strong> {playerB.bestCheckout}</p>
                     <p><strong>Najlepší leg:</strong> {playerB.bestLeg}</p>
@@ -92,7 +93,7 @@ function ThrowsList({ throws, playerA, playerB }) {
                 const legWinner = legThrows.find(t => t.checkout)?.playerId;
                 return (
                     <div key={leg}>
-                        <h2 className={`text-xl font-bold mt-4 ${legWinner === playerA.id ? 'text-blue-700' : legWinner === playerB.id ? 'text-red-700' : ''}`}>
+                        <h2 className={`text-xl font-bold mt-4 p-2 ${legWinner === playerA.id ? 'bg-blue-200 text-blue-800' : legWinner === playerB.id ? 'bg-red-200 text-red-800' : ''}`}>
                             Leg {leg}
                         </h2>
                         <div className="overflow-x-auto">
@@ -106,10 +107,10 @@ function ThrowsList({ throws, playerA, playerB }) {
                                 <tbody className="divide-y divide-gray-200 *:even:bg-gray-50">
                                     {getLegRows(legThrows, playerA.id, playerB.id).map((row, i) => (
                                         <tr key={i} className="*:text-gray-900">
-                                            <td className={`px-1 py-2 whitespace-nowrap ${row.playerA?.first ? 'font-bold' : ''} ${row.playerA?.checkout ? 'text-green-600' : ''}`}>
+                                            <td className={`px-1 py-2 whitespace-nowrap ${row.playerA?.first ? 'font-bold' : ''} ${row.playerA?.last ? 'text-green-600 font-bold' : ''}`}>
                                                 {row.playerA?.score}
                                             </td>
-                                            <td className={`px-3 py-2 whitespace-nowrap ${row.playerB?.first ? 'font-bold' : ''} ${row.playerB?.checkout ? 'text-green-600' : ''}`}>
+                                            <td className={`px-3 py-2 whitespace-nowrap ${row.playerB?.first ? 'font-bold' : ''} ${row.playerB?.last ? 'text-green-600 font-bold' : ''}`}>
                                                 {row.playerB?.score}
                                             </td>
                                         </tr>
@@ -129,21 +130,22 @@ function getLegRows(legThrows, playerAId, playerBId) {
     const playerAThrows = legThrows.filter(t => t.playerId === playerAId);
     const playerBThrows = legThrows.filter(t => t.playerId === playerBId);
     const numRows = Math.max(playerAThrows.length, playerBThrows.length);
+    const firstThrow = legThrows.length > 0 ? legThrows[0] : null;
 
     for (let i = 0; i < numRows; i++) {
         const row = { playerA: null, playerB: null };
         if (playerAThrows[i]) {
             row.playerA = {
-                score: playerAThrows[i].score,
-                checkout: playerAThrows[i].checkout,
-                first: i === 0,
+                score: playerAThrows[i].checkout ? `${playerAThrows[i].score} D` : playerAThrows[i].score,
+                first: firstThrow && playerAThrows[i].id === firstThrow.id,
+                last: playerAThrows[i].checkout,
             };
         }
         if (playerBThrows[i]) {
             row.playerB = {
-                score: playerBThrows[i].score,
-                checkout: playerBThrows[i].checkout,
-                first: i === 0,
+                score: playerBThrows[i].checkout ? `${playerBThrows[i].score} D` : playerBThrows[i].score,
+                first: firstThrow && playerBThrows[i].id === firstThrow.id,
+                last: playerBThrows[i].checkout,
             };
         }
         rows.push(row);

--- a/app/tournaments/[id]/match/[matchId]/page.tsx
+++ b/app/tournaments/[id]/match/[matchId]/page.tsx
@@ -108,10 +108,10 @@ function ThrowsList({ throws, playerA, playerB }) {
                                     {getLegRows(legThrows, playerA.id, playerB.id).map((row, i) => (
                                         <tr key={i} className="*:text-gray-900">
                                             <td className={`px-1 py-2 whitespace-nowrap ${row.playerA?.first ? 'font-bold' : ''} ${row.playerA?.last ? 'text-green-600 font-bold' : ''}`}>
-                                                {row.playerA?.score}
+                                                {row.playerA && <span>{row.playerA.remaining} <span className="text-gray-500">({row.playerA.score})</span></span>}
                                             </td>
                                             <td className={`px-3 py-2 whitespace-nowrap ${row.playerB?.first ? 'font-bold' : ''} ${row.playerB?.last ? 'text-green-600 font-bold' : ''}`}>
-                                                {row.playerB?.score}
+                                                {row.playerB && <span>{row.playerB.remaining} <span className="text-gray-500">({row.playerB.score})</span></span>}
                                             </td>
                                         </tr>
                                     ))}
@@ -132,18 +132,29 @@ function getLegRows(legThrows, playerAId, playerBId) {
     const numRows = Math.max(playerAThrows.length, playerBThrows.length);
     const firstThrow = legThrows.length > 0 ? legThrows[0] : null;
 
+    let remainingA = 501;
+    let remainingB = 501;
+
     for (let i = 0; i < numRows; i++) {
         const row = { playerA: null, playerB: null };
         if (playerAThrows[i]) {
+            const score = playerAThrows[i].score;
+            const remainingBefore = remainingA;
+            remainingA -= score;
             row.playerA = {
-                score: playerAThrows[i].checkout ? `${playerAThrows[i].score} D` : playerAThrows[i].score,
+                score: playerAThrows[i].checkout ? `${score} D` : score,
+                remaining: remainingBefore,
                 first: firstThrow && playerAThrows[i].id === firstThrow.id,
                 last: playerAThrows[i].checkout,
             };
         }
         if (playerBThrows[i]) {
+            const score = playerBThrows[i].score;
+            const remainingBefore = remainingB;
+            remainingB -= score;
             row.playerB = {
-                score: playerBThrows[i].checkout ? `${playerBThrows[i].score} D` : playerBThrows[i].score,
+                score: playerBThrows[i].checkout ? `${score} D` : score,
+                remaining: remainingBefore,
                 first: firstThrow && playerBThrows[i].id === firstThrow.id,
                 last: playerBThrows[i].checkout,
             };

--- a/app/tournaments/[id]/tables/[table]/choose-player.tsx
+++ b/app/tournaments/[id]/tables/[table]/choose-player.tsx
@@ -3,6 +3,7 @@
 import { startMatch } from "@/app/lib/match";
 import { Match } from "@prisma/client";
 import { useFormStatus } from "react-dom";
+import Image from "next/image";
 
 export default function ChoosePlayer({ match, table }: { match: Match, table: string }) {
 
@@ -44,7 +45,7 @@ function Player({ playerId, image, name }) {
             <div className="flex flex-col">
                 <div className={`p-4 m-6 border-slate-400 border-2 bg-blue-300 rounded shadow ${pending && "bg-slate-200"}`}>
                     <div className="flex items-center justify-center flex-row basis-1/2">
-                        <img src={image} className="w-14 "></img>
+                        <Image src={image} alt={name} width={56} height={56} className="w-14 " />
                         <div className={"flex items-center justify-center text-center p-2 text-3xl"}>
                             {name}
                         </div>

--- a/app/tournaments/[id]/tables/[table]/darts.tsx
+++ b/app/tournaments/[id]/tables/[table]/darts.tsx
@@ -27,8 +27,8 @@ export default async function Darts({ table, matchId, slow, reset }: { table: st
       firstPlayer: "1",
       tournamentId: "test",
     },
-    playerA: { matchAvg: 10, score: 501, active: true, id: "1", name: "Fero Hruska", dartsCount: 3, imageUrl: "abc", lastThrow: 41, legCount: 0 },
-    playerB: { matchAvg: 30, score: 501, active: false, id: "2", name: "Jozo Mrkva", dartsCount: 6, imageUrl: "abc", lastThrow: 41, legCount: 1 },
+    playerA: { matchAvg: 10, score: 501, active: true, id: "1", name: "Fero Hruska", dartsCount: 3, imageUrl: "abc", lastThrow: 41, legCount: 0, highestScore: 0, bestCheckout: 0, bestLeg: 0 },
+    playerB: { matchAvg: 30, score: 501, active: false, id: "2", name: "Jozo Mrkva", dartsCount: 6, imageUrl: "abc", lastThrow: 41, legCount: 1, highestScore: 0, bestCheckout: 0, bestLeg: 0 },
     nextPlayer: "1",
     currentLeg: 1,
   };

--- a/app/tournaments/[id]/tables/[table]/player-name.tsx
+++ b/app/tournaments/[id]/tables/[table]/player-name.tsx
@@ -1,9 +1,10 @@
 import { Player } from "@/app/lib/model/fullmatch";
+import Image from "next/image";
 
 export default function PlayerName({ player }: { player: Player }) {
   return (
     <div className="flex items-center justify-center overflow-y-auto">
-      <img src={player.imageUrl} className="w-12 "></img>
+      <Image src={player.imageUrl} alt={player.name} width={48} height={48} className="w-12 " />
       <div className={"flex h-16 items-center justify-center text-center p-2 text-xl font-bold" + (player.active && " text-blue-700")}>
         {player.name}
       </div>

--- a/app/tournaments/[id]/tables/[table]/tournament-header.tsx
+++ b/app/tournaments/[id]/tables/[table]/tournament-header.tsx
@@ -1,13 +1,17 @@
 import { resetMatch } from "@/app/lib/match";
 import { Tournament } from "@prisma/client";
+import Image from "next/image";
 
 export default function TournamentHeader({ tournament, round, format, table, matchId, reset }: { tournament: Tournament, round: string, format: string, table: string, matchId: string, reset: boolean }) {
   return (
     <div className="flex flex-row basis-1/12 bg-blue-200 p-1 pl-3 text-xl text-slate-800">
       <div className="flex flex-cols items-center justify-left">
         <div>
-          <img
+          <Image
             src="https://img.cuescore.com/image/3/2/31bf20bde717adc6cb934d7b8fddd79d.png"
+            alt={tournament.name}
+            width={48}
+            height={48}
             className="w-12"
           />
         </div>

--- a/app/tournaments/[id]/tables/[table]/wait.tsx
+++ b/app/tournaments/[id]/tables/[table]/wait.tsx
@@ -12,7 +12,7 @@ export default function Wait({ id, table }) {
       router.push(`/tournaments/${id}/tables/${table}`)
     }, 20000); //This will refresh the data at regularIntervals of refreshTime
     return () => clearInterval(comInterval) //Clear interval on component unmount to avoid memory leak
-  }, [])
+  }, [id, router, table])
 
   return (
     <div className="flex flex-col h-dvh bg-slate-300 align-middle text-center text-2xl text-blue-700">

--- a/app/tournaments/[id]/tables/[table]/winner.tsx
+++ b/app/tournaments/[id]/tables/[table]/winner.tsx
@@ -6,6 +6,7 @@ import { finishMatch } from "@/app/lib/cuescore";
 import { Match } from "@prisma/client";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react"
+import Image from "next/image";
 
 export default function Winner({ player, image, match, leg, slow, table }: { player: string, image: string, match: Match, leg: number, slow: boolean, table: string }) {
 
@@ -16,12 +17,12 @@ export default function Winner({ player, image, match, leg, slow, table }: { pla
       finishMatch(match.tournamentId, match.id, match.playerALegs, match.playerBlegs, table)
     }, 20000); //This will refresh the data at regularIntervals of refreshTime
     return () => clearInterval(comInterval) //Clear interval on component unmount to avoid memory leak
-  }, [])
+  }, [match.tournamentId, match.id, match.playerALegs, match.playerBlegs, table])
 
   return (
     <div className="flex flex-col text-center justify-center items-center content-center">
       Winner:
-      <img src={image} className="w-20"></img>
+      <Image src={image} alt={player} width={80} height={80} className="w-20" />
       <div className={"flex p-2 text-2xl font-bold"}>
         {player}
       </div>

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,12 +1,13 @@
+const { pathsToModuleNameMapper } = require('ts-jest');
+const { compilerOptions } = require('./tsconfig.json');
+
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/__integration_tests__/**/*.test.ts'],
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/$1',
-  },
+  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: '<rootDir>/' }),
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: 'tsconfig.json' }],
   },
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+require('@testing-library/jest-dom');

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "jest-mock-extended": "^4.0.0",
         "next": "^14.2.4",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "ts-node": "^10.9.2"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.24.7",
@@ -678,7 +679,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -690,7 +690,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2481,26 +2480,22 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "devOptional": true
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA=="
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
@@ -3123,6 +3118,13 @@
       "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
       "dev": true
     },
+    "node_modules/@vercel/node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vercel/node/node_modules/async-listen": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/async-listen/-/async-listen-3.0.0.tgz",
@@ -3157,6 +3159,50 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
+    },
+    "node_modules/@vercel/node/node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/node/node_modules/typescript": {
       "version": "4.9.5",
@@ -3349,7 +3395,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
-      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3380,7 +3425,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
       "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4433,8 +4477,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -4710,7 +4753,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "devOptional": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -9434,8 +9476,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "devOptional": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -11895,10 +11936,10 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "devOptional": true,
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11940,8 +11981,7 @@
     "node_modules/ts-node/node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/ts-toolbelt": {
       "version": "6.15.5",
@@ -12238,8 +12278,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -12803,7 +12842,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
       "engines": {
         "node": ">=6"
       }


### PR DESCRIPTION
This change enhances the tournament results page by adding a list of matches in the tournament. It also creates a new page with details of each match.

The match details page includes:
- Player statistics for the match.
- A list of all throws in the match, grouped by leg.

The layout is consistent with the existing design and is optimized for mobile.

The following changes were made:
- Added a new page for match details at `app/tournaments/[id]/match/[matchId]/page.tsx`.
- Enhanced the tournament stats page at `app/stats/tournaments/[id]/page.tsx` to include a list of matches.
- Added new data fetching functions to `app/lib/data.ts`.
- Refactored the `Header` component for reusability.
- Fixed all integration tests to ensure they pass reliably.