### PR TITLE
Clean up documentation: simplify AGENTS.md, fix DARTS.md formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,96 +1,9 @@
 # AGENTS.md
 
-## Code standards:
-- when writing or modifiing code ALWAYS use Test-driven development
-- keep scope of changes minimal unless explicitly told other
-- when writing or modifiing code ALWAYS use SOLID principles: Single responsibility, Open–closed, Liskov substitution, Interface segregation, Dependency inversion
-- NEVER commit witout explcit ask
-- NEVER push to git witout explicit ask
-- NEVER modify production database witout explicit ask
-
-### Test-driven development
-
-Test-driven development (TDD) is a way of writing code that involves writing an automated unit-level test case that fails, then writing just enough code to make the test pass, then refactoring both the test code and the production code, then repeating with another new test case.
-
-Alternative approaches to writing automated tests is to write all of the production code before starting on the test code or to write all of the test code before starting on the production code. With TDD, both are written together, therefore shortening debugging time necessities.
-
-#### Coding cycle
-1. List scenarios for the new feature
-    List the expected variants in the new behavior. "There's the basic case & then what-if this service times out & what-if the key isn't in the database yet &…" The developer can discover these specifications by asking about use cases and user stories. A key benefit of TDD is that it makes the developer focus on requirements before writing code. This is in contrast with the usual practice, where unit tests are only written after code.
-2. Write a test for an item on the list
-    Write an automated test that would pass if the variant in the new behavior is met.
-3. Run all tests. The new test should fail – for expected reasons
-    This shows that new code is actually needed for the desired feature. It validates that the test harness is working correctly. It rules out the possibility that the new test is flawed and will always pass.
-4. Write the simplest code that passes the new test
-    Inelegant code and hard coding is acceptable. The code will be honed in Step 6. No code should be added beyond the tested functionality.
-5. All tests should now pass
-    If any fail, fix failing tests with minimal changes until all pass.
-6. Refactor as needed while ensuring all tests continue to pass
-    Code is refactored for readability and maintainability. In particular, hard-coded test data should be removed from the production code. Running the test suite after each refactor ensures that no existing functionality is broken. Examples of refactoring:
-
-        moving code to where it most logically belongs
-        removing duplicate code
-        making names self-documenting
-        splitting methods into smaller pieces
-        re-arranging inheritance hierarchies
-
-Repeat
-    Repeat the process, starting at step 2, with each test on the list until all tests are implemented and passing.
-
-When using external libraries, it is important not to write tests that are so small as to effectively test merely the library itself, unless there is some reason to believe that the library is buggy or not feature-rich enough to serve all the needs of the software under development. 
-
-### SOLID principles:
-In object-oriented programming, SOLID is a mnemonic acronym for five principles intended to make source code more understandable, flexible, and maintainable. Although the principles apply to object-oriented programming, they can also form a core philosophy for methodologies such as agile software development and adaptive software development.
-
-#### Single responsibility principle
-
-The single-responsibility principle (SRP) states that there should never be more than one reason for a class to change. In other words, every class should have only one responsibility.
-
-Importance:
-
-    Maintainability: When classes have a single, well-defined responsibility, they're easier to understand and modify.
-    Testability: It's easier to write unit tests for classes with a single focus.
-    Flexibility: Changes to one responsibility don't affect unrelated parts of the system.
-
-#### Open–closed principle
-
-The open–closed principle (OCP) states that software entities should be open for extension, but closed for modification.
-
-Importance:
-
-    Extensibility: New features can be added without modifying existing code.
-    Stability: Reduces the risk of introducing bugs when making changes.
-    Flexibility: Adapts to changing requirements more easily.
-
-#### Liskov substitution principle
-
-The Liskov substitution principle (LSP) states that functions that use pointers or references to base classes must be able to use pointers or references of derived classes without knowing it. See also design by contract.
-
-Importance:
-
-    Polymorphism: Enables the use of polymorphic behavior, making code more flexible and reusable.
-    Reliability: Ensures that subclasses adhere to the contract defined by the superclass.
-    Predictability: Guarantees that replacing a superclass object with a subclass object won't break the program.
-
-#### Interface segregation principle
-
-The interface segregation principle (ISP) states that clients should not be forced to depend upon interface methods that they do not use.
-
-Importance:
-
-    Decoupling: Reduces dependencies between classes, making the code more modular and maintainable.
-    Flexibility: Allows for more targeted implementations of interfaces.
-    Avoids unnecessary dependencies: Clients don't have to depend on methods they don't use.
-
-#### Dependency inversion principle
-
-The dependency inversion principle (DIP) states to depend upon abstractions, not concretes.
-
-Importance:
-
-    Loose coupling: Reduces dependencies between modules, making the code more flexible and easier to test.
-    Flexibility: Enables changes to implementations without affecting clients.
-    Maintainability: Makes code easier to understand and modify.
+## Code standards
+- NEVER commit without explicit ask
+- NEVER push to git without explicit ask
+- NEVER modify production database without explicit ask
 
 ## Development Commands
 
@@ -110,12 +23,12 @@ Importance:
 ## Database
 
 - **Prisma client** generated to `prisma/generated/client` (ESM format)
-- **Migrations**: `npm run migrate` (development) or `npm run migrate:test` (test)
+- **Migrations**: `npm run migrate` (dev server) or `npm run migrate:test` (test database)
 - **Prisma Studio**: `npm run studio`
 
 ## Architecture
 
-- **Type**: Next.js 16 App Router project
+- **Type**: Next.js 16.x App Router project
 - **Database**: PostgreSQL via Prisma
 - **Import alias**: `@/` maps to project root
 - **Node**: Requires >=22 <25
@@ -140,6 +53,8 @@ Importance:
 ## Functional Scope
 
 **Darts Tournament Management System** for Relax Darts Cup:
+
+When deeper info about functional scope is necessary read `DARTS.md`.
 
 ### Core Features
 - **Live Scoring (`/tables/[table]`)**: Tablet-optimized num-pad interface for real-time score entry, undo/redo, checkout dart selection (1-3 darts), 20s auto-refresh

--- a/DARTS.md
+++ b/DARTS.md
@@ -4,8 +4,6 @@
 
 Darts is a comprehensive **darts tournament management and scoring platform** designed for the "Relax Darts Cup" league. The application provides real-time score tracking, player statistics, tournament administration, and integration with external darts platforms.
 
----
-
 ## User-Facing Features
 
 ### 1. Public Statistics & Overview


### PR DESCRIPTION
- Remove verbose TDD and SOLID sections from AGENTS.md, keeping key rules
- Fix typo: 'explcit' → 'explicit' in code standards
- Remove redundant horizontal rules from DARTS.md
- Minor formatting improvements