### PR TITLE
fix: add redirect to startMatch and fix UI test failures

### DIFF
--- a/app/__tests__/match.test.ts
+++ b/app/__tests__/match.test.ts
@@ -20,6 +20,9 @@ jest.mock('next/cache', () => ({
     revalidateTag: jest.fn(),
     revalidatePath: jest.fn(),
 }));
+jest.mock('next/navigation', () => ({
+    redirect: jest.fn(),
+}));
 
 const mockMatch: Match & { tournament: { id: string; name: string } } = {
     id: 'm1',
@@ -127,8 +130,10 @@ describe('match', () => {
         formData.append('firstPlayer', 'pA');
         formData.append('table', '1');
         jest.mocked(data.updateMatchFirstPlayer).mockResolvedValue(null);
+        const { redirect } = await import('next/navigation');
         await match.startMatch(formData);
         expect(data.updateMatchFirstPlayer).toHaveBeenCalledWith('m1', 'pA');
+        expect(redirect).toHaveBeenCalledWith('/tables/1');
     });
 
     test('getThrows', async () => {

--- a/app/lib/__tests__/match-caching.test.ts
+++ b/app/lib/__tests__/match-caching.test.ts
@@ -15,6 +15,10 @@ jest.mock('next/cache', () => ({
   revalidateTag: jest.fn(),
 }))
 
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn(),
+}))
+
 describe('Dashboard caching - match invalidation', () => {
   const { revalidateTag } = jest.requireMock('next/cache') as Record<string, jest.Mock>
   
@@ -30,8 +34,10 @@ describe('Dashboard caching - match invalidation', () => {
     formData.set('firstPlayer', 'p1')
     formData.set('table', '3')
 
+    const { redirect } = require('next/navigation')
     await startMatch(formData)
 
     expect(revalidateTag).toHaveBeenCalledWith('match3', 'max')
+    expect(redirect).toHaveBeenCalledWith('/tables/3')
   })
 })

--- a/app/lib/match.ts
+++ b/app/lib/match.ts
@@ -2,6 +2,7 @@
 
 import getTournamentInfo from "./cuescore"
 import { revalidatePath, revalidateTag } from "next/cache";
+import { redirect } from "next/navigation";
 import { FullMatch, Player } from "./model/fullmatch";
 import { findLastThrow, findMatchAvg } from "./playerThrow";
 import { findMatch, findThrowsByMatch, findThrowsByMatchAndLeg, findActiveThrowsByMatchAndLeg, findHighestScoreInMatch, findBestCheckoutInMatch, findBestLegInMatch, findScoreboardThrowHistory, upsertMatch, updateMatchFirstPlayer } from "./data";
@@ -121,10 +122,12 @@ export async function setStartingPlayer(matchId, playerId) {
 
 export async function startMatch(formData) {
    await setStartingPlayer(formData.get('matchId'), formData.get('firstPlayer'));
+   const table = formData.get('table');
    revalidatePath('/tables/[table]', 'page');
-   const cacheTag = `match${formData.get('table')}`
+   const cacheTag = `match${table}`
    console.log('revalidating tag', cacheTag)
    revalidateTag(cacheTag, 'max')
+   redirect(`/tables/${encodeURIComponent(table)}`);
   }
 
   export async function getThrows(matchId: string, leg: number, playerA: string, playerB: string) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ const chromiumExecutablePath = resolveChromiumExecutablePath();
 
 export default defineConfig({
   testDir: './tests/ui',
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: Boolean(process.env.CI),
   retries: process.env.CI ? 2 : 0,
   reporter: [['list'], ['html', { open: 'never' }]],
@@ -23,15 +23,15 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium-desktop',
-      use: {
-        ...devices['Desktop Chrome'],
-      },
-    },
-    {
       name: 'chromium-mobile',
       use: {
         ...devices['Pixel 7'],
+      },
+    },
+    {
+      name: 'chromium-desktop',
+      use: {
+        ...devices['Desktop Chrome'],
       },
     },
   ],

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Parse arguments
+VERBOSE=false
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -v|--verbose) VERBOSE=true ;;
+        *) echo "Unknown parameter: $1"; exit 1 ;;
+    esac
+    shift
+done
+
+log() {
+    if [ "$VERBOSE" = true ]; then
+        echo "$@"
+    fi
+}
+
+log_verbose() {
+    if [ "$VERBOSE" = true ]; then
+        echo "[INFO] $@"
+    fi
+}
+
+# Stage exit codes: 1=build, 2=unit, 3=integration, 4=UI, 5=E2E
+STAGE_FAILED=0
+
+# Track what we started
+started_db=false
+
+cleanup() {
+    local exit_code=$?
+    log_verbose "Cleaning up..."
+
+    # Kill any processes on test ports
+    if command -v fuser &> /dev/null; then
+        fuser -k 3001/tcp 2>/dev/null || true
+        fuser -k 3002/tcp 2>/dev/null || true
+    fi
+
+    # Stop DB only if we started it
+    if [ "$started_db" = true ]; then
+        log_verbose "Stopping PostgreSQL server..."
+        podman stop darts-postgres-test >/dev/null 2>&1 || true
+        podman rm darts-postgres-test >/dev/null 2>&1 || true
+    fi
+
+    if [ $STAGE_FAILED -ne 0 ]; then
+        exit $STAGE_FAILED
+    fi
+    exit $exit_code
+}
+
+trap cleanup EXIT
+
+# Create .env.test if missing
+if [ ! -f .env.test ]; then
+    echo "Creating .env.test from .env.example"
+    cp .env.example .env.test
+fi
+
+# Source environment variables
+if [ -f .env.test ]; then
+    export $(cat .env.test | sed 's/#.*//g' | xargs)
+fi
+
+# Find an available port
+find_free_port() {
+    local port
+    while true; do
+        port=$((RANDOM % 10000 + 10000))
+        if ! nc -z 127.0.0.1 $port 2>/dev/null; then
+            echo $port
+            return
+        fi
+    done
+}
+
+# Detect or start DB
+DB_PORT=$(find_free_port)
+log_verbose "Using database port: $DB_PORT"
+db_url="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${DB_PORT}/darts-test"
+if nc -z 127.0.0.1 $DB_PORT >/dev/null 2>&1; then
+    log_verbose "Using existing PostgreSQL server on 127.0.0.1:$DB_PORT"
+    started_db=false
+else
+    log "Starting PostgreSQL server on port $DB_PORT..."
+    started_db=true
+    podman run -d --name darts-postgres-test -e POSTGRES_USER="${POSTGRES_USER}" -e POSTGRES_PASSWORD="${POSTGRES_PASSWORD}" -e POSTGRES_DB=darts-test -p ${DB_PORT}:5432 --rm postgres:15-alpine
+
+    log "Waiting for PostgreSQL to be ready..."
+    until nc -z 127.0.0.1 $DB_PORT >/dev/null 2>&1; do
+        >&2 echo "Postgres is unavailable - sleeping"
+        sleep 1
+    done
+    echo "Postgres is up - continuing..."
+fi
+
+export POSTGRES_PRISMA_URL="$db_url"
+export POSTGRES_URL_NON_POOLING="$db_url"
+
+# Kill any existing servers on test ports
+log_verbose "Checking for existing servers on ports 3001/3002..."
+if command -v fuser &> /dev/null; then
+    fuser -k 3001/tcp 2>/dev/null || true
+    fuser -k 3002/tcp 2>/dev/null || true
+fi
+
+# === BUILD ===
+log "Building..."
+if ! npm run build; then
+    STAGE_FAILED=1
+    exit 1
+fi
+
+# === UNIT TESTS ===
+log "Running unit tests..."
+if ! npm run test; then
+    STAGE_FAILED=2
+    exit 1
+fi
+
+# === INTEGRATION TESTS ===
+log "Running integration tests..."
+if ! npm run test:integration; then
+    STAGE_FAILED=3
+    exit 1
+fi
+
+# === UI TESTS ===
+log "Running UI tests..."
+if ! npm run test:ui; then
+    STAGE_FAILED=4
+    exit 1
+fi
+
+# Kill any lingering servers after UI tests
+log_verbose "Cleaning up servers after UI tests..."
+if command -v fuser &> /dev/null; then
+    fuser -k 3001/tcp 2>/dev/null || true
+fi
+
+# === E2E TESTS ===
+log "Running E2E tests..."
+if ! npm run migrate:test; then
+    STAGE_FAILED=5
+    exit 1
+fi
+if ! npm run test:ui:e2e:runner; then
+    STAGE_FAILED=5
+    exit 1
+fi
+
+echo "All tests completed successfully."

--- a/tests/ui/scoreboard.spec.ts
+++ b/tests/ui/scoreboard.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page, type TestInfo } from '@playwright/test';
 
 async function openStartedTableOne(page: Page, testInfo: TestInfo) {
-  const tournamentId = `ui-scoreboard-${testInfo.project.name}-${testInfo.parallelIndex}-${Date.now()}`;
+  const tournamentId = `ui-scoreboard-${testInfo.project.name}-${testInfo.parallelIndex}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 
   await page.goto('/tournaments');
   await page.getByPlaceholder('Tournament ID').fill(tournamentId);
@@ -11,8 +11,12 @@ async function openStartedTableOne(page: Page, testInfo: TestInfo) {
   await page.getByRole('link', { name: 'Table 1' }).click();
   await expect(page).toHaveURL(/\/tables\/1$/);
   await expect(page.getByText('First to play:')).toBeVisible();
+  
+  // Wait for form submission and redirect
   await page.locator('[data-testid^="start-player-"]').first().click();
-  await expect(page.getByRole('button', { name: 'UNDO' })).toBeVisible();
+  
+  // Wait for the scoreboard to appear (indicates successful navigation)
+  await expect(page.getByRole('button', { name: 'UNDO' })).toBeVisible({ timeout: 10000 });
 }
 
 test.describe('scoreboard UI', () => {


### PR DESCRIPTION
- Add redirect to startMatch server action after setting first player
- Update unit tests to mock redirect function
- Fix UI test to wait for navigation after form submission
- Change UI tests to run sequentially to avoid DB state conflicts
- Update run-all-tests.sh to use random available port for PostgreSQL