### PR TITLE
refactor: consolidate leg turn logic into leg-turn module

### DIFF
--- a/app/dashboard/dashboard-view.tsx
+++ b/app/dashboard/dashboard-view.tsx
@@ -3,30 +3,7 @@
 import { useEffect, useState } from 'react';
 import NoActiveTournament from '@/app/components/NoActiveTournament';
 import DartIcon from '@/app/components/DartIcon';
-
-function selectCurrentLegStarter({
-    leg,
-    playerAId,
-    playerBId,
-    firstPlayer,
-}: {
-    leg?: number | null
-    playerAId?: string | null
-    playerBId?: string | null
-    firstPlayer?: string | null
-}) {
-    if (!Number.isInteger(leg) || !playerAId || !playerBId || !firstPlayer) {
-        return null;
-    }
-
-    if (firstPlayer !== playerAId && firstPlayer !== playerBId) {
-        return null;
-    }
-
-    return leg! % 2 === 1
-        ? firstPlayer
-        : firstPlayer === playerAId ? playerBId : playerAId;
-}
+import { getNextPlayer, getLegStarter } from '@/app/lib/leg-turn'
 
 const ACTIVE_TOURNAMENT_NOT_SET = 'ACTIVE_TOURNAMENT_NOT_SET';
 
@@ -106,20 +83,23 @@ function formatAverageValue(average?: number) {
 }
 
 function TableDashboard({ tableId, match, matchInfo, lastThrows, liveState, firstPlayer, avgPlayerA, avgPlayerB }: { tableId: string, match: any, matchInfo: any, lastThrows?: any[], liveState?: any, firstPlayer?: string, avgPlayerA?: number, avgPlayerB?: number }) {
-    function nextPlayer(leg: number, throwsA: number, throwsB: number, playerA: string, playerB: string, firstPlayer: string) {
-        if ((leg + (throwsA ? throwsA : 0) + (throwsB ? throwsB : 0)) % 2 == 1) {
-            return firstPlayer;
-        } else {
-            return firstPlayer == playerA ? playerB : playerA;
-        }
-    }
-
     const leg = (match?.scoreA || 0) + (match?.scoreB || 0) + 1;
     const playerAId = match?.playerA?.playerId?.toString();
     const playerBId = match?.playerB?.playerId?.toString();
     const playerAInfo = matchInfo?.find(e => e.playerId == playerAId)
     const playerBInfo = matchInfo?.find(e => e.playerId == playerBId)
-    const fallbackNextPlayer = match && firstPlayer ? nextPlayer(leg, playerAInfo?._count?.score, playerBInfo?._count?.score, playerAId, playerBId, firstPlayer) : null;
+    
+    const fallbackNextPlayer = match && firstPlayer && playerAId && playerBId
+      ? getNextPlayer({
+          currentLeg: leg,
+          throwsByA: playerAInfo?._count?.id ?? 0,
+          throwsByB: playerBInfo?._count?.id ?? 0,
+          firstPlayer,
+          playerAId,
+          playerBId,
+        })
+      : null;
+    
     const nextP = liveState?.activePlayerId ?? fallbackNextPlayer;
     const projectedLastThrows = Array.isArray(liveState?.lastThrows) ? liveState.lastThrows : null;
     const currentLastThrows = projectedLastThrows ?? lastThrows;
@@ -127,12 +107,15 @@ function TableDashboard({ tableId, match, matchInfo, lastThrows, liveState, firs
     const playerBScore = liveState ? liveState.playerBScoreLeft : 501 - (playerBInfo?._sum?.score || 0);
     const playerAAvgDisplay = liveState ? formatAverage(liveState.playerATotalScore, liveState.playerATotalDarts) : formatAverageValue(avgPlayerA);
     const playerBAvgDisplay = liveState ? formatAverage(liveState.playerBTotalScore, liveState.playerBTotalDarts) : formatAverageValue(avgPlayerB);
-    const startingPlayerId = liveState?.startingPlayerId ?? (match && firstPlayer ? selectCurrentLegStarter({
-        leg,
-        playerAId,
-        playerBId,
-        firstPlayer,
-    }) : null);
+    
+    const startingPlayerId = liveState?.startingPlayerId ?? (match && firstPlayer && playerAId && playerBId
+        ? getLegStarter({
+            leg,
+            firstPlayer,
+            playerAId,
+            playerBId,
+          })
+        : null);
     return (
         <div className="relative bg-gray-800 p-2 md:p-4 rounded-xl shadow-lg ring-1 ring-white/10 flex flex-col items-center justify-center space-y-2 md:space-y-4" data-testid={`dashboard-table-${tableId}`}>
             <h1 className="absolute top-2 left-2 text-xs md:text-sm font-bold text-gray-500">#{tableId}</h1>

--- a/app/lib/__tests__/leg-turn.test.ts
+++ b/app/lib/__tests__/leg-turn.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from '@jest/globals'
+import { getNextPlayer, getLegStarter } from '../leg-turn'
+
+describe('leg-turn', () => {
+  describe('getNextPlayer', () => {
+    test('returns null when firstPlayer is null', () => {
+      expect(
+        getNextPlayer({
+          currentLeg: 1,
+          throwsByA: 0,
+          throwsByB: 0,
+          firstPlayer: null,
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBeNull()
+    })
+
+    test('returns other player when throwCount is odd', () => {
+      expect(
+        getNextPlayer({
+          currentLeg: 1,
+          throwsByA: 1,
+          throwsByB: 0,
+          firstPlayer: 'pA',
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBe('pB')
+    })
+
+    test('returns firstPlayer when throwCount is even', () => {
+      expect(
+        getNextPlayer({
+          currentLeg: 1,
+          throwsByA: 1,
+          throwsByB: 1,
+          firstPlayer: 'pA',
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBe('pA')
+    })
+
+    test('alternates correctly with firstPlayer as playerB', () => {
+      expect(
+        getNextPlayer({
+          currentLeg: 1,
+          throwsByA: 0,
+          throwsByB: 0,
+          firstPlayer: 'pB',
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBe('pB')
+
+      expect(
+        getNextPlayer({
+          currentLeg: 1,
+          throwsByA: 0,
+          throwsByB: 1,
+          firstPlayer: 'pB',
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBe('pA')
+    })
+  })
+
+  describe('getLegStarter', () => {
+    test('returns null when firstPlayer is null', () => {
+      expect(
+        getLegStarter({
+          leg: 1,
+          firstPlayer: null,
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBeNull()
+    })
+
+    test('returns firstPlayer for odd legs', () => {
+      expect(
+        getLegStarter({
+          leg: 1,
+          firstPlayer: 'pA',
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBe('pA')
+
+      expect(
+        getLegStarter({
+          leg: 3,
+          firstPlayer: 'pA',
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBe('pA')
+    })
+
+    test('returns other player for even legs', () => {
+      expect(
+        getLegStarter({
+          leg: 2,
+          firstPlayer: 'pA',
+          playerAId: 'pA',
+          playerBId: 'pB',
+        })
+      ).toBe('pB')
+    })
+  })
+})

--- a/app/lib/leg-turn.ts
+++ b/app/lib/leg-turn.ts
@@ -1,0 +1,38 @@
+export type LegTurnContext = {
+  currentLeg: number
+  throwsByA: number
+  throwsByB: number
+  firstPlayer: string | null
+  playerAId: string
+  playerBId: string
+}
+
+export type LegStarterContext = {
+  leg: number
+  firstPlayer: string | null
+  playerAId: string
+  playerBId: string
+}
+
+export function getNextPlayer(ctx: LegTurnContext): string | null {
+  const { currentLeg, throwsByA, throwsByB, firstPlayer, playerAId, playerBId } = ctx
+
+  if (!firstPlayer) {
+    return null
+  }
+
+  const throwCount = throwsByA + throwsByB
+  const nextPlayer = (currentLeg + throwCount) % 2 === 1 ? firstPlayer : (firstPlayer === playerAId ? playerBId : playerAId)
+
+  return nextPlayer
+}
+
+export function getLegStarter(ctx: LegStarterContext): string | null {
+  const { leg, firstPlayer, playerAId, playerBId } = ctx
+
+  if (!firstPlayer) {
+    return null
+  }
+
+  return leg % 2 === 1 ? firstPlayer : (firstPlayer === playerAId ? playerBId : playerAId)
+}

--- a/app/lib/match-live-state/builder.ts
+++ b/app/lib/match-live-state/builder.ts
@@ -1,5 +1,6 @@
 import type { MatchLiveState } from './model'
 import { STARTING_SCORE } from '../scoring'
+import { getNextPlayer } from '../leg-turn'
 
 export type MatchForLiveState = {
     id: string
@@ -38,18 +39,6 @@ function findLegGroup(groups: LegTotalsGroup[], playerId: string) {
     return groups.find(g => g.playerId === playerId)
 }
 
-function getNextActivePlayer(
-    leg: number,
-    throwCount: number,
-    firstPlayer: string | null,
-    playerAId: string,
-    playerBId: string
-): string | null {
-    if (!firstPlayer) return null
-    if ((leg + throwCount) % 2 === 1) return firstPlayer
-    return firstPlayer === playerAId ? playerBId : playerAId
-}
-
 export function buildMatchLiveState(
     match: MatchForLiveState,
     table: string | null | undefined,
@@ -66,13 +55,14 @@ export function buildMatchLiveState(
 
     const throwCount = (playerALegTotals?._count?.id ?? 0) + (playerBLegTotals?._count?.id ?? 0)
 
-    const activePlayerId = getNextActivePlayer(
-        leg,
-        throwCount,
-        match.firstPlayer,
-        match.playerAId,
-        match.playerBId
-    )
+    const activePlayerId = getNextPlayer({
+        currentLeg: leg,
+        throwsByA: playerALegTotals?._count?.id ?? 0,
+        throwsByB: playerBLegTotals?._count?.id ?? 0,
+        firstPlayer: match.firstPlayer,
+        playerAId: match.playerAId,
+        playerBId: match.playerBId,
+    })
 
     const lastThrowsData = lastThrows.map(t => ({
         playerId: t.playerId,

--- a/app/lib/match-state/index.ts
+++ b/app/lib/match-state/index.ts
@@ -1,5 +1,6 @@
 import { findMatch, findThrowsByMatch, findScoreboardThrowHistory, findHighestScoreInMatch, findBestCheckoutInMatch, findBestLegInMatch, aggregateMatchThrows } from '@/app/lib/data'
 import { calculateThreeDartAverage, STARTING_SCORE } from '@/app/lib/scoring'
+import { getNextPlayer, getLegStarter } from '@/app/lib/leg-turn'
 import type { Match, Tournament, PlayerThrow } from '@/prisma/client'
 
 export type PlayerStats = {
@@ -35,16 +36,6 @@ export type MatchState = {
     status: 'active' | 'undone'
     activityTime: Date
   }>
-}
-
-function getCurrentLegStarter(leg: number, firstPlayer: string | null, playerAId: string, playerBId: string): string | null {
-  if (!firstPlayer || !Number.isInteger(leg) || !playerAId || !playerBId) {
-    return null
-  }
-  if (firstPlayer !== playerAId && firstPlayer !== playerBId) {
-    return null
-  }
-  return leg % 2 === 1 ? firstPlayer : (firstPlayer === playerAId ? playerBId : playerAId)
 }
 
 async function getPlayerMatchStats(matchId: string, playerId: string) {
@@ -86,12 +77,21 @@ export async function getMatchState(matchId: string): Promise<MatchState | null>
   const playerADarts = playerALegThrows.reduce((s, t) => s + t.darts, 0)
   const playerBDarts = playerBLegThrows.reduce((s, t) => s + t.darts, 0)
 
-  const throwCount = playerALegThrows.length + playerBLegThrows.length
-  const nextPlayer = match.firstPlayer
-    ? (leg + throwCount) % 2 === 1 ? match.firstPlayer : (match.firstPlayer === match.playerAId ? match.playerBId : match.playerAId)
-    : match.playerAId
+  const nextPlayer = getNextPlayer({
+    currentLeg: leg,
+    throwsByA: playerALegThrows.length,
+    throwsByB: playerBLegThrows.length,
+    firstPlayer: match.firstPlayer,
+    playerAId: match.playerAId,
+    playerBId: match.playerBId,
+  })
 
-  const currentLegStarter = getCurrentLegStarter(leg, match.firstPlayer, match.playerAId, match.playerBId)
+  const currentLegStarter = getLegStarter({
+    leg,
+    firstPlayer: match.firstPlayer,
+    playerAId: match.playerAId,
+    playerBId: match.playerBId,
+  })
 
   const [playerAStats, playerBStats] = await Promise.all([
     getPlayerMatchStats(matchId, match.playerAId),

--- a/app/lib/scoring.ts
+++ b/app/lib/scoring.ts
@@ -1,3 +1,5 @@
+import { getNextPlayer, type LegTurnContext } from './leg-turn'
+
 export type ScoringThrow = {
   id: string
   playerId: string
@@ -43,7 +45,7 @@ const SCORING_DART_SCORES = Array.from(
     ...BOARD_NUMBERS.map((n) => n * 2),
     ...BOARD_NUMBERS.map((n) => n * 3),
     50,
-  ])
+  ]),
 ).sort((a, b) => a - b)
 
 const FINISHING_DOUBLE_SCORES = Array.from(
@@ -94,29 +96,28 @@ export function calculateLegState(params: {
     startingScore = STARTING_SCORE,
   } = params
 
-  const playerAStats = throws
-    .filter((t) => t.playerId === playerAId)
+  const playerAThrows = throws.filter((t) => t.playerId === playerAId)
+  const playerBThrows = throws.filter((t) => t.playerId === playerBId)
+
+  const playerAStats = playerAThrows
     .reduce(
       (acc, t) => ({ sum: acc.sum + t.score, count: acc.count + t.darts }),
       { sum: 0, count: 0 }
     )
-  const playerBStats = throws
-    .filter((t) => t.playerId === playerBId)
+  const playerBStats = playerBThrows
     .reduce(
       (acc, t) => ({ sum: acc.sum + t.score, count: acc.count + t.darts }),
       { sum: 0, count: 0 }
     )
 
-  const throwCount = throws.length
-  let nextPlayer: string | null = null
-
-  if (firstPlayer) {
-    if ((leg + throwCount) % 2 === 1) {
-      nextPlayer = firstPlayer
-    } else {
-      nextPlayer = firstPlayer === playerAId ? playerBId : playerAId
-    }
-  }
+  const nextPlayer = getNextPlayer({
+    currentLeg: leg,
+    throwsByA: playerAThrows.length,
+    throwsByB: playerBThrows.length,
+    firstPlayer,
+    playerAId,
+    playerBId,
+  })
 
   return {
     playerAScoreLeft: startingScore - playerAStats.sum,


### PR DESCRIPTION
- Extract getNextPlayer and getLegStarter functions into app/lib/leg-turn.ts
- Update scoring.ts, match-state/index.ts, builder.ts, dashboard-view.tsx to use consolidated functions
- Use throw count (number of throws) instead of darts count for turn logic
- Add tests for leg-turn module